### PR TITLE
Fetch account to get latest nonce xPortal

### DIFF
--- a/vue-mvx-demo/src/views/Transaction.vue
+++ b/vue-mvx-demo/src/views/Transaction.vue
@@ -56,6 +56,7 @@ const accountBalance = computed(() => {
 })
 
 async function sendTransaction() {
+    account.value = await fetchAccount();
     transactionResult.value = null;
     transactionState.value = null;
     transactionUrl.value = null;


### PR DESCRIPTION
If users "sendTransaction()" with xPortal while the app isn't opened, the app won't ask for the transaction to be signed, but the account nonce will be incremented line 74.
Next time the user opens the xPortal app and uses "sendTransaction()" the nonces won't be correct and the transactions will keep on failing.
To avoid desyncing the nonce of our account we should fetchAccount() just before incrementing the nonce.