### PR TITLE
Guarded transactions for WebWallet & simple word transaction data fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@niftywell/vue-erdjs-workspaces",
+    "name": "vue-erdjs-workspaces",
     "workspaces": [
         "vue-mvx",
         "vue-mvx-demo"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "vue-erdjs-workspaces",
+    "name": "@niftywell/vue-erdjs-workspaces",
     "workspaces": [
         "vue-mvx",
         "vue-mvx-demo"

--- a/vue-mvx/README.md
+++ b/vue-mvx/README.md
@@ -1,24 +1,32 @@
 <div align="center">
-  <h1>@niftywell/vue-mvx</h1>
-  <p>Intermediary VueJS Plugin for MultiversX Dapp Integration</p>
-  <p>This package serves as a temporary solution incorporating additional features like 2FA signing for MultiversX until the official release.</p>
+  <h1>Vue MultiversX Dapp Plugin</h1>
+  <p>This VueJS plugin provide MultiversX integration for your Dapp</p>
+  <p>
+    <a href="https://npmcharts.com/compare/vue-mvx?minimal=true" alt="NPM weekly downloads">
+      <img src="https://badgen.net/npm/dw/vue-mvx">
+    </a>
+    <a href="https://www.npmtrends.com/vue-mvx" alt="NPM total downloads">
+      <img src="https://badgen.net/npm/dt/vue-mvx">
+    </a>
+    <a href="https://npmjs.com/vue-mvx" alt="NPM version">
+      <img src="https://badgen.net/npm/v/vue-mvx">
+    </a>
+  </p>
 </div>
 
-> Note: This is an intermediary version of the Vue MultiversX Dapp Plugin. The official version with these updates will be available in the original package soon.
+> Library is now in release candidate (You are welcome if you want to help)
+>
+![](src/_docs/authenticate.png)
 
-![](src/_docs/authenticate.png) <!-- Keep original image -->
+[Go to the demo](https://stephaneleroy.github.io/vue-mvx/authenticate)
 
-[Go to the demo of the original package](https://stephaneleroy.github.io/vue-mvx/authenticate)
+You can find a DApp example in [example folder](https://github.com/stephaneLeroy/vue-mvx/tree/vue3-migration/vue-mvx-demo).
 
-You can find the original DApp example in the [example folder](https://github.com/stephaneLeroy/vue-mvx/tree/vue3-migration/vue-mvx-demo).
+## Getting started with the plugin
 
-## Getting Started with the Plugin
+You can find documentation [here](https://stephaneleroy.github.io/vue-mvx/plugin/vue-mvx.html)
 
-For documentation, please refer to the [original plugin documentation](https://stephaneleroy.github.io/vue-mvx/plugin/vue-mvx.html).
-
-## Getting Started for Developers
-
-The development process remains the same as the original package:
+## Getting started for developers
 
 ``` bash
 # install dependencies
@@ -29,3 +37,24 @@ npm run dev
 
 # build for production with minification
 npm run build
+```
+
+## Roadmap
+
+- [x] Init project and build management
+- [x] In project DApp example
+- [x] Add Maiar App Login
+- [x] Add Ledger Login
+- [x] Add Web Wallet Login
+- [x] Add Defi Wallet
+- [x] Token login signature for backend authentication
+- [x] Add Local storage login cache
+- [x] Migrate to typescript
+- [x] Fancier DApp UI
+- [x] Optimize production build
+- [x] Factorize webpack configuration
+- [x] Publish DApp example on github page
+- [x] release candidate :tada:
+- [x] Parameters, library
+- [ ] Styling documentation
+- [x] Vue3 /next branch and compatibility

--- a/vue-mvx/README.md
+++ b/vue-mvx/README.md
@@ -1,32 +1,24 @@
 <div align="center">
-  <h1>Vue MultiversX Dapp Plugin</h1>
-  <p>This VueJS plugin provide MultiversX integration for your Dapp</p>
-  <p>
-    <a href="https://npmcharts.com/compare/vue-mvx?minimal=true" alt="NPM weekly downloads">
-      <img src="https://badgen.net/npm/dw/vue-mvx">
-    </a>
-    <a href="https://www.npmtrends.com/vue-mvx" alt="NPM total downloads">
-      <img src="https://badgen.net/npm/dt/vue-mvx">
-    </a>
-    <a href="https://npmjs.com/vue-mvx" alt="NPM version">
-      <img src="https://badgen.net/npm/v/vue-mvx">
-    </a>
-  </p>
+  <h1>@niftywell/vue-mvx</h1>
+  <p>Intermediary VueJS Plugin for MultiversX Dapp Integration</p>
+  <p>This package serves as a temporary solution incorporating additional features like 2FA signing for MultiversX until the official release.</p>
 </div>
 
-> Library is now in release candidate (You are welcome if you want to help)
->
-![](src/_docs/authenticate.png)
+> Note: This is an intermediary version of the Vue MultiversX Dapp Plugin. The official version with these updates will be available in the original package soon.
 
-[Go to the demo](https://stephaneleroy.github.io/vue-mvx/authenticate)
+![](src/_docs/authenticate.png) <!-- Keep original image -->
 
-You can find a DApp example in [example folder](https://github.com/stephaneLeroy/vue-mvx/tree/vue3-migration/vue-mvx-demo).
+[Go to the demo of the original package](https://stephaneleroy.github.io/vue-mvx/authenticate)
 
-## Getting started with the plugin
+You can find the original DApp example in the [example folder](https://github.com/stephaneLeroy/vue-mvx/tree/vue3-migration/vue-mvx-demo).
 
-You can find documentation [here](https://stephaneleroy.github.io/vue-mvx/plugin/vue-mvx.html)
+## Getting Started with the Plugin
 
-## Getting started for developers
+For documentation, please refer to the [original plugin documentation](https://stephaneleroy.github.io/vue-mvx/plugin/vue-mvx.html).
+
+## Getting Started for Developers
+
+The development process remains the same as the original package:
 
 ``` bash
 # install dependencies
@@ -37,24 +29,3 @@ npm run dev
 
 # build for production with minification
 npm run build
-```
-
-## Roadmap
-
-- [x] Init project and build management
-- [x] In project DApp example
-- [x] Add Maiar App Login
-- [x] Add Ledger Login
-- [x] Add Web Wallet Login
-- [x] Add Defi Wallet
-- [x] Token login signature for backend authentication
-- [x] Add Local storage login cache
-- [x] Migrate to typescript
-- [x] Fancier DApp UI
-- [x] Optimize production build
-- [x] Factorize webpack configuration
-- [x] Publish DApp example on github page
-- [x] release candidate :tada:
-- [x] Parameters, library
-- [ ] Styling documentation
-- [x] Vue3 /next branch and compatibility

--- a/vue-mvx/package.json
+++ b/vue-mvx/package.json
@@ -42,13 +42,13 @@
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
     },
     "dependencies": {
-        "@multiversx/sdk-core": "^12.8.0",
+        "@multiversx/sdk-core": "^12.11.1",
         "@multiversx/sdk-extension-provider": "^3.0.0",
         "@multiversx/sdk-hw-provider": "^6.4.0",
         "@multiversx/sdk-wallet": "^4.2.0",
-        "@multiversx/sdk-wallet-connect-provider": "^4.0.2",
+        "@multiversx/sdk-wallet-connect-provider": "^4.0.4",
         "@multiversx/sdk-web-wallet-provider": "^3.1.0",
-        "@multiversx/sdk-network-providers": "^2.0.0",
+        "@multiversx/sdk-network-providers": "^2.2.0",
         "dayjs": "^1.10.7",
         "mitt": "^3.0.0",
         "platform": "^1.3.6",

--- a/vue-mvx/package.json
+++ b/vue-mvx/package.json
@@ -25,7 +25,7 @@
     "sideEffects": true,
     "repository": {
         "type": "git",
-        "url": "https://github.com/NiftyWell/vue-mvx"
+        "url": "https://github.com/stephaneLeroy/vue-mvx"
     },
     "keywords": [
         "MultiversX",

--- a/vue-mvx/package.json
+++ b/vue-mvx/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "@niftywell/vue-mvx",
+    "name": "vue-mvx",
     "description": "MultiversX js dapp sdk integration for vuejs",
     "version": "1.1.1",
-    "author": "leroys, niftywell",
+    "author": "leroys",
     "license": "MIT",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",

--- a/vue-mvx/package.json
+++ b/vue-mvx/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "vue-mvx",
+    "name": "@niftywell/vue-mvx",
     "description": "MultiversX js dapp sdk integration for vuejs",
     "version": "1.1.1",
-    "author": "leroys",
+    "author": "leroys, niftywell",
     "license": "MIT",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",
@@ -25,7 +25,7 @@
     "sideEffects": true,
     "repository": {
         "type": "git",
-        "url": "https://github.com/stephaneLeroy/vue-mvx"
+        "url": "https://github.com/NiftyWell/vue-mvx"
     },
     "keywords": [
         "MultiversX",

--- a/vue-mvx/src/providers/web/WebWalletStrategy.ts
+++ b/vue-mvx/src/providers/web/WebWalletStrategy.ts
@@ -1,97 +1,73 @@
-import {
-    Address,
-    TransactionVersion,
-    Transaction,
-    TransactionOptions,
-    TransactionPayload,
-} from "@multiversx/sdk-core"
-import { WalletProvider } from "@multiversx/sdk-web-wallet-provider"
-import type IProviderStrategy from "../IProviderStrategy"
-import type IProviderStrategyEventHandler from "../IProviderStrategyEventHandler"
-import type { WebWalletOption } from "../config"
-import StorageProvider from "../storage/StorageProvider"
-import dayjs from "dayjs"
-import { isStringBase64 } from "./base64Utils"
+import {Address, TransactionVersion, Transaction, TransactionOptions, TransactionPayload} from "@multiversx/sdk-core";
+import {WalletProvider} from '@multiversx/sdk-web-wallet-provider';
+import type IProviderStrategy from "../IProviderStrategy";
+import type IProviderStrategyEventHandler from "../IProviderStrategyEventHandler";
+import type {WebWalletOption} from "../config";
+import StorageProvider from "../storage/StorageProvider";
+import dayjs from "dayjs";
+import {isStringBase64} from "./base64Utils";
 
 class WebWalletProviderStrategy implements IProviderStrategy {
-    private _eventHandler: IProviderStrategyEventHandler
-    private _webWallet: WalletProvider
-    private _lastStatus?: string
-    private _storage = new StorageProvider("web-wallet-strategy")
-    private _timeoutInMinutes = 30
+    private _eventHandler: IProviderStrategyEventHandler;
+    private _webWallet: WalletProvider;
+    private _lastStatus?: string;
+    private _storage = new StorageProvider('web-wallet-strategy');
+    private _timeoutInMinutes = 30;
 
-    constructor(
-        eventHandler: IProviderStrategyEventHandler,
-        options: WebWalletOption
-    ) {
-        this._eventHandler = eventHandler
-        this._webWallet = new WalletProvider(`${options.url}/init`)
-        this._lastStatus = undefined
+    constructor(eventHandler: IProviderStrategyEventHandler, options: WebWalletOption) {
+        this._eventHandler = eventHandler;
+        this._webWallet = new WalletProvider(`${options.url}/init`);
+        this._lastStatus = undefined;
     }
 
     id() {
-        return "web-wallet"
+        return "web-wallet";
     }
 
     name() {
-        return "Web Wallet"
+        return "Web Wallet";
     }
 
     provider() {
-        return this._webWallet
+        return this._webWallet;
     }
 
     callbackReceived(url: Location) {
-        const urlSearchParams = new URLSearchParams(url.search)
+        const urlSearchParams = new URLSearchParams(url.search);
 
-        const address = urlSearchParams.get("address")
-        const token = urlSearchParams.get("signature")
+        const address = urlSearchParams.get('address');
+        const token = urlSearchParams.get('signature');
         if (address) {
-            this._storage.set(
-                { wallet: address, token: token },
-                dayjs().add(this._timeoutInMinutes, "minute")
-            )
-            this._eventHandler.handleLogin(
-                this,
-                new Address(address),
-                token ? token : undefined
-            )
+            this._storage.set({ wallet: address, token: token  } , dayjs().add(this._timeoutInMinutes, 'minute'))
+            this._eventHandler.handleLogin(this, new Address(address), token ? token : undefined)
         }
 
-        const status = urlSearchParams.get("status")
+        const status = urlSearchParams.get('status');
         if (status) {
-            this._lastStatus = status
+            this._lastStatus = status;
         } else {
-            this._lastStatus = undefined
+            this._lastStatus = undefined;
         }
     }
 
     get lastStatus() {
-        return this._lastStatus
+        return this._lastStatus;
     }
 
-    login(options?: {
-        addressIndex?: number
-        callbackUrl?: string
-        token?: string
-    }): Promise<any> {
-        this._eventHandler.handleLogin(this)
-        return this._webWallet.login(options)
+    login(options?: { addressIndex?: number, callbackUrl?: string, token?: string }): Promise<any> {
+        this._eventHandler.handleLogin(this);
+        return this._webWallet.login(options);
     }
 
     logout() {
-        this._storage.clear()
-        this._webWallet.logout()
+        this._storage.clear();
+        this._webWallet.logout();
     }
 
     load() {
-        const stored = this._storage.get()
+        let stored = this._storage.get();
         if (stored) {
-            this._eventHandler.handleLogin(
-                this,
-                new Address(stored.wallet),
-                stored.token
-            )
+            this._eventHandler.handleLogin(this, new Address(stored.wallet), stored.token);
             this.onUrl(window.location)
         } else {
             this.callbackReceived(window.location)
@@ -99,19 +75,18 @@ class WebWalletProviderStrategy implements IProviderStrategy {
     }
 
     onUrl(url: Location) {
-        const transactions = this._webWallet.getTransactionsFromWalletUrl()
+        const transactions = this._webWallet.getTransactionsFromWalletUrl();
         console.log("On Url", url, transactions)
-        if (!transactions || transactions.length <= 0) {
+        if(!transactions || transactions.length <= 0) {
             return
         }
 
-        transactions.forEach(rawTransaction => {
-            const { data } = rawTransaction
-            console.log("this is the raw transaction")
-            console.log(rawTransaction)
-            const dataPayload = isStringBase64(data ?? "")
+        transactions.forEach((rawTransaction) => {
+
+            const { data } = rawTransaction;
+            const dataPayload = isStringBase64(data ?? '')
                 ? TransactionPayload.fromEncoded(data)
-                : new TransactionPayload(data)
+                : new TransactionPayload(data);
 
             const transaction = new Transaction({
                 value: rawTransaction.value.valueOf(),
@@ -124,13 +99,9 @@ class WebWalletProviderStrategy implements IProviderStrategy {
                 chainID: rawTransaction.chainID.valueOf(),
                 version: new TransactionVersion(rawTransaction.version),
                 ...(rawTransaction.options
-                    ? {
-                          options: new TransactionOptions(
-                              rawTransaction.options
-                          ),
-                      }
-                    : {}),
-            })
+                    ? { options: new TransactionOptions(rawTransaction.options) }
+                    : {})
+            });
             // Add guardian signature when needed
             if (rawTransaction.guardianSignature) {
                 transaction.applyGuardianSignature({
@@ -140,26 +111,21 @@ class WebWalletProviderStrategy implements IProviderStrategy {
             }
             transaction.applySignature(
                 {
-                    hex: () => rawTransaction.signature || "",
-                }
+                    hex: () => rawTransaction.signature || ''
+                },
                 //new Address(rawTransaction.sender)
-            )
-            this._eventHandler.handleTransaction(transaction)
+            );
+            this._eventHandler.handleTransaction(transaction);
+
         })
     }
 
-    signTransaction(
-        transaction: Transaction,
-        options?: { callbackUrl?: string }
-    ): Promise<Transaction | void> {
-        return this.provider().signTransaction(transaction, options)
+    signTransaction(transaction: Transaction, options?: { callbackUrl?: string }): Promise<Transaction | void> {
+        return this.provider().signTransaction(transaction, options);
     }
-    signTransactions(
-        transaction: Transaction[],
-        options?: { callbackUrl?: string }
-    ): Promise<Transaction[] | void> {
+    signTransactions(transaction: Transaction[], options?: { callbackUrl?: string }): Promise<Transaction[] | void> {
         return this.provider().signTransactions(transaction)
     }
 }
 
-export default WebWalletProviderStrategy
+export default WebWalletProviderStrategy;

--- a/vue-mvx/src/providers/web/WebWalletStrategy.ts
+++ b/vue-mvx/src/providers/web/WebWalletStrategy.ts
@@ -1,73 +1,97 @@
-import {Address, TransactionVersion, Transaction, TransactionOptions, TransactionPayload} from "@multiversx/sdk-core";
-import {WalletProvider} from '@multiversx/sdk-web-wallet-provider';
-import type IProviderStrategy from "../IProviderStrategy";
-import type IProviderStrategyEventHandler from "../IProviderStrategyEventHandler";
-import type {WebWalletOption} from "../config";
-import StorageProvider from "../storage/StorageProvider";
-import dayjs from "dayjs";
-import {isStringBase64} from "./base64Utils";
+import {
+    Address,
+    TransactionVersion,
+    Transaction,
+    TransactionOptions,
+    TransactionPayload,
+} from "@multiversx/sdk-core"
+import { WalletProvider } from "@multiversx/sdk-web-wallet-provider"
+import type IProviderStrategy from "../IProviderStrategy"
+import type IProviderStrategyEventHandler from "../IProviderStrategyEventHandler"
+import type { WebWalletOption } from "../config"
+import StorageProvider from "../storage/StorageProvider"
+import dayjs from "dayjs"
+import { isStringBase64 } from "./base64Utils"
 
 class WebWalletProviderStrategy implements IProviderStrategy {
-    private _eventHandler: IProviderStrategyEventHandler;
-    private _webWallet: WalletProvider;
-    private _lastStatus?: string;
-    private _storage = new StorageProvider('web-wallet-strategy');
-    private _timeoutInMinutes = 30;
+    private _eventHandler: IProviderStrategyEventHandler
+    private _webWallet: WalletProvider
+    private _lastStatus?: string
+    private _storage = new StorageProvider("web-wallet-strategy")
+    private _timeoutInMinutes = 30
 
-    constructor(eventHandler: IProviderStrategyEventHandler, options: WebWalletOption) {
-        this._eventHandler = eventHandler;
-        this._webWallet = new WalletProvider(`${options.url}/init`);
-        this._lastStatus = undefined;
+    constructor(
+        eventHandler: IProviderStrategyEventHandler,
+        options: WebWalletOption
+    ) {
+        this._eventHandler = eventHandler
+        this._webWallet = new WalletProvider(`${options.url}/init`)
+        this._lastStatus = undefined
     }
 
     id() {
-        return "web-wallet";
+        return "web-wallet"
     }
 
     name() {
-        return "Web Wallet";
+        return "Web Wallet"
     }
 
     provider() {
-        return this._webWallet;
+        return this._webWallet
     }
 
     callbackReceived(url: Location) {
-        const urlSearchParams = new URLSearchParams(url.search);
+        const urlSearchParams = new URLSearchParams(url.search)
 
-        const address = urlSearchParams.get('address');
-        const token = urlSearchParams.get('signature');
+        const address = urlSearchParams.get("address")
+        const token = urlSearchParams.get("signature")
         if (address) {
-            this._storage.set({ wallet: address, token: token  } , dayjs().add(this._timeoutInMinutes, 'minute'))
-            this._eventHandler.handleLogin(this, new Address(address), token ? token : undefined)
+            this._storage.set(
+                { wallet: address, token: token },
+                dayjs().add(this._timeoutInMinutes, "minute")
+            )
+            this._eventHandler.handleLogin(
+                this,
+                new Address(address),
+                token ? token : undefined
+            )
         }
 
-        const status = urlSearchParams.get('status');
+        const status = urlSearchParams.get("status")
         if (status) {
-            this._lastStatus = status;
+            this._lastStatus = status
         } else {
-            this._lastStatus = undefined;
+            this._lastStatus = undefined
         }
     }
 
     get lastStatus() {
-        return this._lastStatus;
+        return this._lastStatus
     }
 
-    login(options?: { addressIndex?: number, callbackUrl?: string, token?: string }): Promise<any> {
-        this._eventHandler.handleLogin(this);
-        return this._webWallet.login(options);
+    login(options?: {
+        addressIndex?: number
+        callbackUrl?: string
+        token?: string
+    }): Promise<any> {
+        this._eventHandler.handleLogin(this)
+        return this._webWallet.login(options)
     }
 
     logout() {
-        this._storage.clear();
-        this._webWallet.logout();
+        this._storage.clear()
+        this._webWallet.logout()
     }
 
     load() {
-        let stored = this._storage.get();
+        const stored = this._storage.get()
         if (stored) {
-            this._eventHandler.handleLogin(this, new Address(stored.wallet), stored.token);
+            this._eventHandler.handleLogin(
+                this,
+                new Address(stored.wallet),
+                stored.token
+            )
             this.onUrl(window.location)
         } else {
             this.callbackReceived(window.location)
@@ -75,18 +99,19 @@ class WebWalletProviderStrategy implements IProviderStrategy {
     }
 
     onUrl(url: Location) {
-        const transactions = this._webWallet.getTransactionsFromWalletUrl();
+        const transactions = this._webWallet.getTransactionsFromWalletUrl()
         console.log("On Url", url, transactions)
-        if(!transactions || transactions.length <= 0) {
+        if (!transactions || transactions.length <= 0) {
             return
         }
 
-        transactions.forEach((rawTransaction) => {
-
-            const { data } = rawTransaction;
-            const dataPayload = isStringBase64(data ?? '')
+        transactions.forEach(rawTransaction => {
+            const { data } = rawTransaction
+            console.log("this is the raw transaction")
+            console.log(rawTransaction)
+            const dataPayload = isStringBase64(data ?? "")
                 ? TransactionPayload.fromEncoded(data)
-                : new TransactionPayload(data);
+                : new TransactionPayload(data)
 
             const transaction = new Transaction({
                 value: rawTransaction.value.valueOf(),
@@ -99,27 +124,42 @@ class WebWalletProviderStrategy implements IProviderStrategy {
                 chainID: rawTransaction.chainID.valueOf(),
                 version: new TransactionVersion(rawTransaction.version),
                 ...(rawTransaction.options
-                    ? { options: new TransactionOptions(rawTransaction.options) }
-                    : {})
-            });
-
+                    ? {
+                          options: new TransactionOptions(
+                              rawTransaction.options
+                          ),
+                      }
+                    : {}),
+            })
+            // Add guardian signature when needed
+            if (rawTransaction.guardianSignature) {
+                transaction.applyGuardianSignature({
+                    hex: () => rawTransaction.guardianSignature || "",
+                })
+                transaction.setGuardian(new Address(rawTransaction.guardian))
+            }
             transaction.applySignature(
                 {
-                    hex: () => rawTransaction.signature || ''
-                },
+                    hex: () => rawTransaction.signature || "",
+                }
                 //new Address(rawTransaction.sender)
-            );
-            this._eventHandler.handleTransaction(transaction);
-
+            )
+            this._eventHandler.handleTransaction(transaction)
         })
     }
 
-    signTransaction(transaction: Transaction, options?: { callbackUrl?: string }): Promise<Transaction | void> {
-        return this.provider().signTransaction(transaction, options);
+    signTransaction(
+        transaction: Transaction,
+        options?: { callbackUrl?: string }
+    ): Promise<Transaction | void> {
+        return this.provider().signTransaction(transaction, options)
     }
-    signTransactions(transaction: Transaction[], options?: { callbackUrl?: string }): Promise<Transaction[] | void> {
+    signTransactions(
+        transaction: Transaction[],
+        options?: { callbackUrl?: string }
+    ): Promise<Transaction[] | void> {
         return this.provider().signTransactions(transaction)
     }
 }
 
-export default WebWalletProviderStrategy;
+export default WebWalletProviderStrategy

--- a/vue-mvx/src/providers/web/base64Utils.ts
+++ b/vue-mvx/src/providers/web/base64Utils.ts
@@ -1,7 +1,8 @@
 export function isStringBase64(string: string) {
     try {
-        return window.atob(string);
+        const decodedString = window.atob(string)
+        return decodedString.includes("@")
     } catch (err) {
-        return false;
+        return false
     }
 }

--- a/vue-mvx/src/providers/web/base64Utils.ts
+++ b/vue-mvx/src/providers/web/base64Utils.ts
@@ -1,8 +1,8 @@
 export function isStringBase64(string: string) {
     try {
-        const decodedString = window.atob(string)
-        return decodedString.includes("@")
+        const decodedString = window.atob(string);
+        return decodedString.includes("@");
     } catch (err) {
-        return false
+        return false;
     }
 }


### PR DESCRIPTION
### Summary
This pull request introduces two key updates to the Web Wallet Strategy, focusing on handling transaction data and supporting guarded accounts.

### Changes
`vue-mvx/src/providers/web/base64Utils.ts`:
**Fixed Base64 Encoding Detection in WebWalletStrategy:** 
Previously a transaction with a single word in the data field such as "vue" would be detected as encoded into base64.
The transaction data would then be generated using the `TransactionPayload.fromEncoded(data)` which would change the data into "77+977+9LQ==". 
Sending the transaction would then result in an error 400 which made it impossible to interact with SmartContract endpoints that required no arguments.
Adjusting the isStringBase64 method to more accurately differentiate between plain text and Base64 encoded data by checking if the decoded version contains or not a "@" character seems to fix this issue.

`vue-mvx/src/providers/web/WebWalletStrategy.ts`:
**Guardian Address and Signature Handling:** 
Included guardian address and signature for accounts with guarded accounts in the Web Wallet Strategy.

`vue-mvx/package.json`:
Changes to the latest MultiversX SDK versions